### PR TITLE
Python 3 issue fix for kickbox.py file

### DIFF
--- a/kickbox/api/kickbox.py
+++ b/kickbox/api/kickbox.py
@@ -1,4 +1,4 @@
-import urllib
+import six
 
 class Kickbox(object):
 
@@ -18,10 +18,10 @@ class Kickbox(object):
         """
         body = options['query'] if 'query' in options else {}
 
-        email   = urllib.quote(email)
+        email   = six.moves.urllib.parse.quote(email)
         timeout = options['timeout'] if 'timeout' in options else 6000
 
-        response = self.client.get('/verify?email=' + email + '&timeout=' + `timeout`, body, options)
+        response = self.client.get('/verify?email=' + email + '&timeout=' + str(timeout), body, options)
 
         return response
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     url='http://kickbox.io',
     license='MIT',
     install_requires=[
-        'requests >= 2.1.0'
+        'requests >= 2.1.0',
+        'six >= 1.9.0'
     ],
     packages=[
         'kickbox'


### PR DESCRIPTION
This fixes issues met when using kickbox-python under Python 3.

The main issue was that the code used **urllib.quote** but it should be **urllib.parse.quote** for Python 3.
(See https://docs.python.org/3.2/library/urllib.parse.html#url-quoting)

I fixed it using six to keep compatibility and tested the functionality with both python 2.7 and 3.4.
