### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ import kickbox
 client   = kickbox.Client('Your_API_Key_Here')
 kickbox  = client.kickbox()
 response = kickbox.verify("test@example.com")
+print response.body # The response is in the body attribute
 ```
 
 #### Options


### PR DESCRIPTION
The response object returned by the API call contains an attribute named `body` which actually contains the API response. So `response['result']` would fail where as `response.body['result']` works.
